### PR TITLE
Replace callbacks with LiveData

### DIFF
--- a/app/src/main/java/com/raywenderlich/guardpost/MainActivity.kt
+++ b/app/src/main/java/com/raywenderlich/guardpost/MainActivity.kt
@@ -2,6 +2,7 @@ package com.raywenderlich.guardpost
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.raywenderlich.guardpost.utils.randomString
 import kotlinx.android.synthetic.main.activity_main.*
@@ -27,17 +28,15 @@ class MainActivity : AppCompatActivity() {
       GuardpostAuth.startLogout(this)
     }
 
+    val guardpostAuthReceiver = GuardpostAuthReceiver()
+
+    guardpostAuthReceiver.login.observe(this, Observer {
+      textView.text = it.toString()
+    })
+
     localBroadcastManager.registerReceiver(
       guardpostAuthReceiver,
       GuardpostAuth.BroadcastActions.INTENT_FILTER
     )
   }
-
-  val guardpostAuthReceiver = GuardpostAuthReceiver({
-    textView.text = it.toString()
-  }, {
-    textView.text = "Logged out!"
-  }, {
-    textView.text = it.toString()
-  })
 }

--- a/guardpost/build.gradle
+++ b/guardpost/build.gradle
@@ -31,5 +31,6 @@ dependencies {
   implementation 'androidx.core:core-ktx:1.0.2'
   implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
   implementation 'androidx.browser:browser:1.0.0'
+  implementation "androidx.lifecycle:lifecycle-livedata:2.0.0"
   testImplementation 'junit:junit:4.12'
 }

--- a/guardpost/src/main/java/com/raywenderlich/guardpost/GuardpostAuthReceiver.kt
+++ b/guardpost/src/main/java/com/raywenderlich/guardpost/GuardpostAuthReceiver.kt
@@ -3,31 +3,36 @@ package com.raywenderlich.guardpost
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.raywenderlich.guardpost.data.SSOUser
 
 class GuardpostAuthReceiver(
-    val onLogin: (SSOUser) -> Unit,
-    val onLogout: () -> Unit,
-    val onError: (Int) -> Unit
+  private val _login: MutableLiveData<SSOUser> = MutableLiveData(),
+  private val _logout: MutableLiveData<Boolean> = MutableLiveData(),
+  private val _error: MutableLiveData<Int> = MutableLiveData(),
+  val login: LiveData<SSOUser> = _login,
+  val logout: LiveData<Boolean> = _logout,
+  val error: LiveData<Int> = _error
 ) : BroadcastReceiver() {
 
   override fun onReceive(context: Context?, intent: Intent?) {
     if (null == intent) {
-      onError(GuardpostAuth.AuthErrors.INVALID_RESPONSE)
+      _error.postValue(GuardpostAuth.AuthErrors.INVALID_RESPONSE)
     }
     when (intent?.action) {
       GuardpostAuth.BroadcastActions.LOGIN_SUCCESS ->
-        onLogin(intent.getParcelableExtra(RedirectActivity.EXTRA_RESULT))
+        _login.postValue(intent.getParcelableExtra(RedirectActivity.EXTRA_RESULT))
       GuardpostAuth.BroadcastActions.LOGIN_FAILURE ->
-        onError(GuardpostAuth.AuthErrors.INVALID_RESPONSE)
+        _error.postValue(GuardpostAuth.AuthErrors.INVALID_RESPONSE)
       GuardpostAuth.BroadcastActions.LOGOUT_SUCCESS ->
-        onLogout()
+        _logout.postValue(true)
       GuardpostAuth.BroadcastActions.FAILURE ->
-        onError(
-            intent.getIntExtra(
-                RedirectActivity.EXTRA_RESULT,
-                GuardpostAuth.AuthErrors.INVALID_RESPONSE
-            )
+        _error.postValue(
+          intent.getIntExtra(
+            RedirectActivity.EXTRA_RESULT,
+            GuardpostAuth.AuthErrors.INVALID_RESPONSE
+          )
         )
     }
   }


### PR DESCRIPTION
## What
Replaces callbacks for success/failure listeners with LiveData observers.

## Why
Callback will run in `BroadcastReceiver.onReceive()` and the navigation library won't work.